### PR TITLE
feat: Add environment variable expansion in config files

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -947,7 +947,7 @@ For servers requiring special setup:
    ```json
    {
      "name": "docker-server",
-     "source": "docker://myimage:tag", 
+     "source": "docker://myimage:tag",
      "prefix": "myimage",
      "command": "docker run -i myimage:tag",
      "env": {
@@ -955,6 +955,52 @@ For servers requiring special setup:
      }
    }
    ```
+
+### Environment Variable Expansion
+
+Magg automatically expands environment variables in the `env`, `transport.headers`, and `transport.auth` fields when loading configuration. This allows you to keep secrets and sensitive data out of config files.
+
+**Supported Syntax:**
+- `${VAR}` - Expands to the value of VAR (or stays as-is if VAR doesn't exist)
+- `${VAR:-default}` - Expands to the value of VAR, or 'default' if VAR is unset/empty
+
+**Example Configuration:**
+```json
+{
+  "servers": {
+    "remote-api": {
+      "source": "https://example.com/api-server",
+      "uri": "https://api.example.com/mcp",
+      "transport": {
+        "auth": "Bearer ${API_TOKEN}",
+        "headers": {
+          "X-Environment": "${ENVIRONMENT:-production}"
+        }
+      }
+    },
+    "local-server": {
+      "source": "https://example.com/local-server",
+      "command": "python",
+      "args": ["server.py"],
+      "env": {
+        "DATABASE_URL": "${DATABASE_URL}",
+        "API_KEY": "${API_KEY}",
+        "LOG_LEVEL": "${LOG_LEVEL:-info}"
+      }
+    }
+  }
+}
+```
+
+**Set environment variables before running Magg:**
+```bash
+export API_TOKEN="secret_token_123"
+export DATABASE_URL="postgresql://localhost/mydb"
+export API_KEY="my_api_key"
+magg serve
+```
+
+This approach keeps secrets out of version control while maintaining readable configuration files.
 
 ### Debugging
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "magg"
-version = "0.10.1"
+version = "0.11.0"
 requires-python = ">=3.12"
 description = "MCP Aggregator"
 authors = [{ name = "Phillip Sitbon", email = "phillip.sitbon@gmail.com"}]

--- a/readme.md
+++ b/readme.md
@@ -342,6 +342,50 @@ Example configuration:
 }
 ```
 
+#### Environment Variable Expansion in Configuration
+
+Magg automatically expands environment variables in the `env`, `transport.headers`, and `transport.auth` fields when loading configuration. This allows you to keep secrets and sensitive data out of config files.
+
+**Supported Syntax:**
+- `${VAR}` - Expands to the value of VAR (or stays as-is if VAR doesn't exist)
+- `${VAR:-default}` - Expands to the value of VAR, or 'default' if VAR is unset/empty
+
+**Example:**
+```json
+{
+  "servers": {
+    "remote-api": {
+      "source": "https://example.com/api-server",
+      "uri": "https://api.example.com/mcp",
+      "transport": {
+        "auth": "Bearer ${API_TOKEN}",
+        "headers": {
+          "X-Environment": "${ENVIRONMENT:-production}"
+        }
+      }
+    },
+    "local-server": {
+      "source": "https://example.com/local-server",
+      "command": "python",
+      "args": ["server.py"],
+      "env": {
+        "DATABASE_URL": "${DATABASE_URL}",
+        "API_KEY": "${API_KEY}",
+        "LOG_LEVEL": "${LOG_LEVEL:-info}"
+      }
+    }
+  }
+}
+```
+
+Then set your environment variables before running Magg:
+```bash
+export API_TOKEN="secret_token_123"
+export DATABASE_URL="postgresql://localhost/mydb"
+export API_KEY="my_api_key"
+magg serve
+```
+
 ### Adding Servers
 
 Servers can be added in several ways:

--- a/uv.lock
+++ b/uv.lock
@@ -676,7 +676,7 @@ wheels = [
 
 [[package]]
 name = "magg"
-version = "0.10.1"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Adds automatic expansion of environment variables in server configuration env and transport.headers fields, allowing secrets to be kept out of config files.

Supports ${VAR} and ${VAR:-default} syntax for dynamic configuration values.

Note: Created with coding assistance