### PR TITLE
Fix proxy tool and authentication, addressed in #6 and #8

### DIFF
--- a/magg/auth.py
+++ b/magg/auth.py
@@ -8,7 +8,7 @@ import jwt
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
-from fastmcp.server.auth import BearerAuthProvider
+from fastmcp.server.auth.providers.jwt import JWTVerifier
 
 from .settings import BearerAuthConfig
 
@@ -138,11 +138,11 @@ class BearerAuthManager:
         return self._private_key
 
     @cached_property
-    def provider(self) -> BearerAuthProvider:
-        """Get the FastMCP BearerAuthProvider for server authentication.
+    def provider(self) -> JWTVerifier:
+        """Get the FastMCP JWTVerifier for server authentication.
 
         Returns:
-            BearerAuthProvider instance
+            JWTVerifier instance
 
         Raises:
             RuntimeError: If authentication is not enabled or keys cannot be loaded
@@ -152,7 +152,7 @@ class BearerAuthManager:
 
         self.load_keys()
 
-        return BearerAuthProvider(
+        return JWTVerifier(
             public_key=self._public_key,
             issuer=self.bearer_config.issuer,
             audience=self.bearer_config.audience

--- a/magg/proxy/mixin.py
+++ b/magg/proxy/mixin.py
@@ -220,7 +220,7 @@ class ProxyMCP:
         async with client:
             if capability_type == "tool":
                 result = await client.call_tool(path, args)  # Returns list[TextContent | ImageContent | EmbeddedResource]
-                result = [annotate_content(item, **annotations) for item in result]
+                result = [annotate_content(item, **annotations) for item in result.content]
 
             elif capability_type == "resource":
                 # For resources, the 'path' is the URI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ include = [
 ]
 
 dependencies = [
-    "fastmcp>=2.8.0",
+    "fastmcp>=2.11.0,<3.0.0",
     "aiohttp>=3.12.13",
     "pydantic>=2.11.7",
     "pydantic-settings>=2.10.0",

--- a/test/magg/test_auth.py
+++ b/test/magg/test_auth.py
@@ -11,7 +11,7 @@ from cryptography.hazmat.backends import default_backend
 
 from magg.auth import BearerAuthManager
 from magg.settings import AuthConfig, BearerAuthConfig, ConfigManager
-from fastmcp.server.auth import BearerAuthProvider
+from fastmcp.server.auth.providers.jwt import JWTVerifier
 
 
 class TestBearerAuthConfig:
@@ -289,4 +289,4 @@ class TestBearerAuthManager:
             # Keys should now be loaded
             assert manager._private_key is not None
             assert manager._public_key is not None
-            assert isinstance(provider, BearerAuthProvider)
+            assert isinstance(provider, JWTVerifier)

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 
 [[package]]
@@ -712,7 +712,7 @@ requires-dist = [
     { name = "aiohttp", specifier = ">=3.12.13" },
     { name = "art", specifier = ">=6.5" },
     { name = "cryptography", specifier = ">=45.0.4" },
-    { name = "fastmcp", specifier = ">=2.8.0" },
+    { name = "fastmcp", specifier = ">=2.11.0,<3.0.0" },
     { name = "prompt-toolkit", specifier = ">=3.0.51" },
     { name = "pydantic", specifier = ">=2.11.7" },
     { name = "pydantic-settings", specifier = ">=2.10.0" },


### PR DESCRIPTION
#6 #8 

Lowered the dependency of fastmcp to <3.0.0 and >=2.11.0. This removes the bugs with compatibility

Changed authentication correspondingly to use **jwt** instead of **bearer**.

There is a need for migration to fastmcp >=3.0.0, but it requires a lot of work, because a lot has been changed