### PR TITLE
Add mcp-name ownership marker for MCP Registry publishing; bump to 1.2.1

### DIFF
--- a/docs/mcp-registry.md
+++ b/docs/mcp-registry.md
@@ -47,3 +47,10 @@ not on `PATH` by default — the prebuilt binary above is the simpler route.
 and the pypi package version) must be bumped to match `pyproject.toml` before
 publishing, and the PyPI release must already exist — the registry verifies that the
 referenced package version is published.
+
+**Ownership verification**: the registry proves control of the PyPI package by requiring
+the line `mcp-name: io.github.sitbon/magg` in the package README as published on PyPI
+(it fetches `https://pypi.org/pypi/magg/json` and checks the description). The marker
+lives in `readme.md` (Appearances section) — do not remove it. Because PyPI descriptions
+are immutable per release, a release published without the marker cannot be registered;
+publish a new version instead.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "magg"
-version = "1.2.0"
+version = "1.2.1"
 requires-python = ">=3.12"
 description = "MCP Aggregator"
 authors = [{ name = "Phillip Sitbon", email = "phillip.sitbon@gmail.com"}]

--- a/readme.md
+++ b/readme.md
@@ -497,6 +497,8 @@ and `magg_search_servers` queries the registry as a first-class discovery source
 Glama, GitHub, and npm. See [MCP Registry Documentation](docs/mcp-registry.md) for publishing
 instructions.
 
+mcp-name: io.github.sitbon/magg
+
 ### Awesome GitHub MCP Lists
 
 * [@modelcontextprotocol/servers](https://github.com/modelcontextprotocol/servers)

--- a/server.json
+++ b/server.json
@@ -7,14 +7,14 @@
     "url": "https://github.com/sitbon/magg",
     "source": "github"
   },
-  "version": "1.2.0",
+  "version": "1.2.1",
   "websiteUrl": "https://github.com/sitbon/magg",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "magg",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/uv.lock
+++ b/uv.lock
@@ -902,7 +902,7 @@ wheels = [
 
 [[package]]
 name = "magg"
-version = "1.2.0"
+version = "1.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -1746,8 +1746,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
## Summary

Fixes the `mcp-publisher publish` failure:

> PyPI package 'magg' ownership validation failed. The server name 'io.github.sitbon/magg' must appear as 'mcp-name: io.github.sitbon/magg' in the package README

The registry proves control of the PyPI package by fetching `https://pypi.org/pypi/magg/json` and checking that the marker line appears in the package description. Changes:

- **`readme.md`**: adds `mcp-name: io.github.sitbon/magg` in the Appearances registry paragraph. Verified the marker lands in the built sdist's `PKG-INFO` description — what PyPI serves to the registry.
- **`docs/mcp-registry.md`**: documents the ownership-verification requirement, warns not to remove the marker, and notes that a release published without it can't be registered retroactively.
- **Version bump 1.2.0 → 1.2.1** (`pyproject.toml`, `server.json` both fields, `uv.lock`): PyPI descriptions are immutable per release, so the marker only takes effect with a new release — 1.2.0 can't be fixed in place.

`mcp-publisher validate` passes against the live registry; version-sync tests pass.

After merging: release 1.2.1 to PyPI, then `mcp-publisher publish` should succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011JFaNeMxJCxXhQ3J9RQACR

---
_Generated by [Claude Code](https://claude.ai/code/session_011JFaNeMxJCxXhQ3J9RQACR)_