### PR TITLE
Gate PR Docker image publishing behind push-image label; add GHCR cleanup

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,13 +9,16 @@ on:
       - 'pyproject.toml'
       - 'uv.lock'
       - 'dockerfile'
+      - '.github/workflows/docker-publish.yml'
   pull_request:
     branches: [ main, beta ]
+    types: [ opened, synchronize, reopened, labeled ]
     paths:
       - 'magg/**'
       - 'pyproject.toml'
       - 'uv.lock'
       - 'dockerfile'
+      - '.github/workflows/docker-publish.yml'
   workflow_dispatch:
 
 env:
@@ -74,6 +77,7 @@ jobs:
         with:
           name: dev-image-${{ matrix.python-version }}
           path: dev-image-${{ matrix.python-version }}.tar
+          retention-days: 1
 
   test-dev-image:
     name: Test Dev Container
@@ -109,7 +113,15 @@ jobs:
     runs-on: ubuntu-latest
 
     needs: [build-dev-image, test-dev-image]
-    if: ${{ always() && needs.build-dev-image.result == 'success' && (needs.test-dev-image.result == 'success' || needs.test-dev-image.result == 'skipped') }}
+    # On pull requests, images are only pushed when a maintainer adds the
+    # 'push-image' label, and never from forks (their GITHUB_TOKEN cannot
+    # push packages). Branch and tag pushes always publish.
+    if: >-
+      ${{ always() && needs.build-dev-image.result == 'success' &&
+          (needs.test-dev-image.result == 'success' || needs.test-dev-image.result == 'skipped') &&
+          (github.event_name != 'pull_request' ||
+           (github.event.pull_request.head.repo.full_name == github.repository &&
+            contains(github.event.pull_request.labels.*.name, 'push-image'))) }}
 
     permissions:
       contents: read
@@ -226,7 +238,12 @@ jobs:
           context: .
           file: ./dockerfile
           target: ${{ matrix.target }}
-          push: ${{ github.event_name != 'pull_request' }}
+          # Same policy as Push Dev Images: PRs only push with the
+          # 'push-image' label, and never from forks.
+          push: >-
+            ${{ github.event_name != 'pull_request' ||
+                (github.event.pull_request.head.repo.full_name == github.repository &&
+                 contains(github.event.pull_request.labels.*.name, 'push-image')) }}
           tags: ${{ steps.meta.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -1,0 +1,44 @@
+name: GHCR Cleanup
+
+# Deletes ephemeral container images from GHCR:
+#   - pr-* tags (per-PR images pushed via the 'push-image' label)
+#   - untagged manifests left behind by moving tags (dev, beta, pr-NN, etc.)
+#
+# Complements the cleanup-untagged job in docker-publish.yml, which runs after
+# branch pushes but never on PR events - this catches what it misses (pr-* tags
+# and untagged manifests orphaned by labeled-PR re-pushes).
+#
+# Version tags (1.2.3, 1.2, *-dev-py3.x) and moving branch tags (dev, beta)
+# are never touched, so production systems that pin versions are unaffected.
+
+on:
+  schedule:
+    - cron: '17 4 * * 1'  # Weekly, Monday 04:17 UTC
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (log deletions without making changes)'
+        required: true
+        default: true
+        type: boolean
+
+jobs:
+  cleanup:
+    name: Clean up ephemeral images
+    runs-on: ubuntu-latest
+
+    permissions:
+      packages: write
+
+    steps:
+      - name: Delete pr-* tags and untagged images
+        uses: dataaxiom/ghcr-cleanup-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          package: magg
+          delete-tags: 'pr-*'
+          exclude-tags: 'dev,beta,beta-dev,latest'
+          delete-untagged: true
+          older-than: 1 week
+          dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
+          validate: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ on:
       - 'test/**'
       - 'pyproject.toml'
       - 'uv.lock'
+      - '.github/workflows/test.yml'
   pull_request:
     branches: ['*']
     paths:
@@ -15,6 +16,7 @@ on:
       - 'test/**'
       - 'pyproject.toml'
       - 'uv.lock'
+      - '.github/workflows/test.yml'
 
 permissions:
   contents: read

--- a/readme.md
+++ b/readme.md
@@ -136,6 +136,11 @@ Images are automatically published to GitHub Container Registry with the followi
 - **Branch tags** (from beta branch): `beta`, `beta-dev`
 - **Python-specific dev tags**: `beta-dev-py3.12`, `beta-dev-py3.13`, etc.
 
+Pull requests build and test images but do not publish them unless a maintainer adds the
+`push-image` label, which publishes ephemeral `pr-NN` / `pr-NN-dev` tags (same-repo PRs
+only). Ephemeral `pr-*` tags and untagged manifests are cleaned up weekly; version tags
+are kept forever, so pinned deployments are never affected.
+
 #### Docker Compose
 
 For easier management, use Docker Compose:


### PR DESCRIPTION
## Summary

Changes the Docker publishing policy per discussion: PRs build and test images but no longer publish them by default.

- **`push-image` label gate**: on pull requests, the `Push Dev Images` job and the `pro` image push only run when a maintainer adds the `push-image` label to a same-repo PR (the `labeled` event type re-triggers the workflow, so adding the label publishes without needing a new push). Fork PRs never push — their `GITHUB_TOKEN` can't write packages, which previously would have failed the job outright on the first community PR touching `magg/**`.
- **Artifact retention**: the dev-image tar artifacts are only consumed by the next job in the same run, so they now expire after 1 day instead of eating storage quota for 90.
- **Weekly GHCR cleanup** (`ghcr-cleanup.yml`): deletes ephemeral `pr-*` tags and untagged manifests older than a week, using `dataaxiom/ghcr-cleanup-action` (multi-arch-safe, with post-run validation). This complements the existing `cleanup-untagged` job, which runs after branch pushes but never on PR events. **Version tags (`1.2.3`, `1.2`, `*-dev-py3.x`) and moving branch tags (`dev`, `beta`) are never touched**, so pinned production deployments are unaffected. Manual dispatch supports a dry-run mode (default on).
- Readme documents the PR image policy.

> **Note**: the two `.github/workflows/` file changes must be pushed by a maintainer — neither of this session's credentials has the `workflow` scope. The commit is provided as a `git am`-ready patch; this PR is complete once it's applied and pushed to this branch.

Setup after merge: create the `push-image` label (any color) in the repo's label settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011JFaNeMxJCxXhQ3J9RQACR

---
_Generated by [Claude Code](https://claude.ai/code/session_011JFaNeMxJCxXhQ3J9RQACR)_